### PR TITLE
Remote inspect images via V2 api

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.platform.cloud.coe.ic.gov/centos:7
+FROM docker.platform.cloud.coe.ic.gov/centos7
 
 LABEL VERSION="0.2.0" \
     RUN="docker run -d -p 9000:9000 -p 80:80 -v <silo db/log location>:/usr/silo docker.platform.cloud.coe.ic.gov/nga-r-dev/silo" \
@@ -7,6 +7,7 @@ LABEL VERSION="0.2.0" \
     CLASSIFICATION="UNCLASSIFIED"
 
 RUN mkdir -p silo \
+    && yum install wget -y \
     && update-ca-trust enable \
     && wget http://pki-ldap.ismc.ic.gov/ -r -A *.cer -nd -nv -P /etc/pki/ca-trust/source/anchors/ \
     && update-ca-trust extract
@@ -20,4 +21,4 @@ EXPOSE 9000
 EXPOSE 80
 
 # Start silo
-CMD silo/silo
+CMD ./silo

--- a/build-docker.sh
+++ b/build-docker.sh
@@ -18,10 +18,10 @@ case "${UNAME}" in
     Linux*)     SUDO=sudo;;
 esac
 
-./build-silo.sh
+build-silo.sh
 
 ${SUDO} docker build . -t silo:$VERSION
 ${SUDO} docker tag silo:$VERSION docker.platform.cloud.coe.ic.gov/nga-r-dev/silo:$VERSION
-${SUDO} docker push./ docker.platform.cloud.coe.ic.gov/nga-r-dev/silo:$VERSION
+${SUDO} docker push docker.platform.cloud.coe.ic.gov/nga-r-dev/silo:$VERSION
 
 popd >/dev/null

--- a/handlers.go
+++ b/handlers.go
@@ -173,7 +173,11 @@ func Scan(w http.ResponseWriter, r *http.Request, registries []models.RegistryIn
 		registry, err := registry.CreateRegistry(r.Url, r.Org, r.Username, r.Password)
 		if err != nil {
 			humanError := checkError(err, r.Url, r.Username, r.Password)
-			fmt.Fprint(w, humanError, "\n")
+			respondWithError(w, http.StatusInternalServerError, humanError)
+		}
+
+		if registry == nil {
+			respondWithError(w, http.StatusInternalServerError, "Error creating registry.")
 		}
 
 		images, err := registry.ImagesWithManifests()

--- a/handlers.go
+++ b/handlers.go
@@ -129,11 +129,16 @@ func ScanRegistry(w http.ResponseWriter, r *http.Request) {
 	list := []models.RegistryInfo{}
 	list = append(list, registry)
 	dbImages, err := Scan(w, r, list)
+	if err != nil {
+		respondWithError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
 
 	//clear out image table before scanning
 	err = models.DeleteRegistryImages(db, id)
 	if err != nil {
 		respondWithError(w, http.StatusInternalServerError, err.Error())
+		return
 	}
 
 	models.StoreImage(db, dbImages)
@@ -159,11 +164,16 @@ func ScanRegistries(w http.ResponseWriter, r *http.Request) {
 	fmt.Fprintln(w, "Scanning registries...")
 
 	dbImages, err := Scan(w, r, registries)
+	if err != nil {
+		respondWithError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
 
 	//clear out image table before scanning
 	err = models.ResetImageTable(db)
 	if err != nil {
 		respondWithError(w, http.StatusInternalServerError, err.Error())
+		return
 	}
 
 	models.StoreImage(db, dbImages)

--- a/models/image.go
+++ b/models/image.go
@@ -9,12 +9,12 @@ import (
 )
 
 type Image struct {
-	ID         int    `db:id`
-	RegistryId int    `db:registry_id`
-	Name       string `db:name`
-	Registry   string `db:registry`
-	Org        string `db:org`
-	Manifest   string `db:manifest`
+	ID         int    `db:"id"`
+	RegistryId int    `db:"registry_id"`
+	Name       string `db:"name"`
+	Registry   string `db:"registry"`
+	Org        string `db:"org"`
+	Manifest   string `db:"manifest"`
 	Seed       objects.Seed
 }
 
@@ -218,4 +218,13 @@ func DeleteRegistryImages(db *sql.DB, registryId int) error {
 	_, err := db.Exec("DELETE FROM Image WHERE registry_id=$1", registryId)
 
 	return err
+}
+
+func ImageExists(db *sql.DB, im Image) bool {
+	row := db.QueryRow("SELECT * FROM Image WHERE name=$1 AND registry_id=$2", im.Name, im.RegistryId)
+
+	var result Image
+	err := row.Scan(&result.ID, &result.RegistryId, &result.Name, &result.Registry, &result.Org, &result.Manifest)
+
+	return err == nil
 }

--- a/models/registryinfo.go
+++ b/models/registryinfo.go
@@ -7,19 +7,19 @@ import (
 
 //TODO: find better way to store credentials for low side registries
 type RegistryInfo struct {
-	ID       int    `db:id`
-	Name     string `db:name`
-	Url      string `db:url`
-	Org      string `db:org`
-	Username string `db:username`
-	Password string `db:password`
+	ID       int    `db:"id"`
+	Name     string `db:"name"`
+	Url      string `db:"url"`
+	Org      string `db:"org"`
+	Username string `db:"username"`
+	Password string `db:"password"`
 }
 
 type DisplayRegistry struct {
-	ID       int    `db:id`
-	Name     string `db:name`
-	Url      string `db:url`
-	Org      string `db:org`
+	ID       int    `db:"id"`
+	Name     string `db:"name"`
+	Url      string `db:"url"`
+	Org      string `db:"org"`
 }
 
 func CreateRegistryTable(db *sql.DB) {

--- a/run-silo.sh
+++ b/run-silo.sh
@@ -1,3 +1,3 @@
 #!/usr/bin/env bash
 
-go run main.go database.go handlers.go logger.go routes.go router.go
+go run main.go database.go handlers.go logger.go routes.go router.go constants.go


### PR DESCRIPTION
Changes to get seed manifests from docker V2 registry api and keep old images until scans are complete.