### PR TITLE
#38 - Adding Duplicate Registry Causes Error

### DIFF
--- a/handlers/registries.go
+++ b/handlers/registries.go
@@ -111,6 +111,7 @@ func AddRegistry(w http.ResponseWriter, r *http.Request) {
 			} else {
 				respondWithError(w, http.StatusInternalServerError, err2.Error())
 			}
+			return
 		}
 		reginfo.ID = id
 		respondWithJSON(w, http.StatusCreated, reginfo)

--- a/handlers/registries.go
+++ b/handlers/registries.go
@@ -9,6 +9,7 @@ import (
 	"log"
 	"net/http"
 	"strconv"
+	"strings"
 	"sync"
 
 	"github.com/gorilla/mux"
@@ -104,7 +105,12 @@ func AddRegistry(w http.ResponseWriter, r *http.Request) {
 			id, err2 = models.AddRegistryLite(db, reginfo)
 		}
 		if err2 != nil {
-			respondWithError(w, http.StatusInternalServerError, err.Error())
+			errStr := err2.Error()
+			if strings.Contains(strings.ToLower(errStr), "unique") {
+				respondWithJSON(w, http.StatusBadRequest, "Registry already exists with name " + reginfo.Name)
+			} else {
+				respondWithError(w, http.StatusInternalServerError, err2.Error())
+			}
 		}
 		reginfo.ID = id
 		respondWithJSON(w, http.StatusCreated, reginfo)

--- a/handlers/users.go
+++ b/handlers/users.go
@@ -149,7 +149,12 @@ func AddUser(w http.ResponseWriter, r *http.Request) {
 		id, err2 = models.AddUserLite(db, user)
 	}
 	if err2 != nil {
-		respondWithError(w, http.StatusInternalServerError, err.Error())
+		errStr := err2.Error()
+		if strings.Contains(strings.ToLower(errStr), "unique") {
+			respondWithJSON(w, http.StatusBadRequest, "User already exists with name " + user.Username)
+		} else {
+			respondWithError(w, http.StatusInternalServerError, err2.Error())
+		}
 		return
 	}
 	user.ID = id

--- a/test/registries/registries_test.go
+++ b/test/registries/registries_test.go
@@ -174,6 +174,13 @@ func TestAddRegistry(t *testing.T) {
 	if m["Org"] != "geointseed" {
 		t.Errorf("Expected org to be 'geointseed'. Got '%v'", m["Org"])
 	}
+
+	// try again, we should get an error as the registry exists
+	req, _ = http.NewRequest("POST", "/registries/add", bytes.NewBuffer(payload))
+	req.Header.Set("Authorization", "Token: "+token)
+	response = executeRequest(req)
+
+	checkResponseCode(t, http.StatusBadRequest, response.Code)
 }
 
 func TestDeleteRegistry(t *testing.T) {

--- a/test/users/users_test.go
+++ b/test/users/users_test.go
@@ -99,6 +99,14 @@ func TestAddUser(t *testing.T) {
 	if m["role"] != "admin" {
 		t.Errorf("Expected role to be 'admin'. Got '%v'", m["role"])
 	}
+
+	payload := []byte(`{"username":"test", "password": "hunter17", "role": "admin"}`)
+
+	req, _ := http.NewRequest("POST", "/users/add", bytes.NewBuffer(payload))
+	req.Header.Set("Authorization", "Token: "+token)
+	response = executeRequest(req)
+
+	checkResponseCode(t, http.StatusBadRequest, response.Code)
 }
 
 func TestDeleteUser(t *testing.T) {


### PR DESCRIPTION
Fixing crash and returning appropriate error when adding a duplicate registry or user