### PR TITLE
#39 - Scanning without any registries causes error

### DIFF
--- a/handlers/registries.go
+++ b/handlers/registries.go
@@ -194,8 +194,10 @@ func ScanRegistry(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	models.BuildJobsList(db, &allImages, dbType)
-	models.StoreOrUpdateImages(db, allImages, dbType)
+	if len(allImages) > 0{
+		models.BuildJobsList(db, &allImages, dbType)
+		models.StoreOrUpdateImages(db, allImages, dbType)
+	}
 }
 
 func ScanRegistries(w http.ResponseWriter, r *http.Request) {
@@ -246,8 +248,10 @@ func ScanRegistries(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	models.BuildJobsList(db, &dbImages, dbType)
-	models.StoreImages(db, dbImages, dbType)
+	if len(dbImages) > 0 {
+		models.BuildJobsList(db, &dbImages, dbType)
+		models.StoreImages(db, dbImages, dbType)
+	}
 }
 
 func Scan(w http.ResponseWriter, req *http.Request, registries []models.RegistryInfo) ([]models.Image, error) {

--- a/test/registries/registries_test.go
+++ b/test/registries/registries_test.go
@@ -214,12 +214,23 @@ func TestScanRegistry(t *testing.T) {
 	clearTablePG()
 	clearTable()
 
-	addRegistry()
-
 	payload := []byte(``)
-	req, _ := http.NewRequest("GET", "/registries/1/scan", bytes.NewBuffer(payload))
+	req, _ := http.NewRequest("GET", "/registries/scan", bytes.NewBuffer(payload))
 	req.Header.Set("Authorization", "Token: "+token)
 	response := executeRequest(req)
+
+	checkResponseCode(t, 202, response.Code)
+
+	req, _ = http.NewRequest("GET", "/images", bytes.NewBuffer(payload))
+	response = executeRequest(req)
+
+	checkResponseCode(t, http.StatusOK, response.Code)
+
+	addRegistry()
+
+	req, _ = http.NewRequest("GET", "/registries/1/scan", bytes.NewBuffer(payload))
+	req.Header.Set("Authorization", "Token: "+token)
+	response = executeRequest(req)
 
 	checkResponseCode(t, 202, response.Code)
 


### PR DESCRIPTION
Fixing crash when no images are found in a scan.